### PR TITLE
Add section to explain how to specify area

### DIFF
--- a/usage/index.md
+++ b/usage/index.md
@@ -82,6 +82,22 @@ The notifier will persist the alerts during the current request only.
 Alert::view()->error('Error message');
 ```
 
+#### Alert Areas
+
+In addition to a message, the various notifiers accept an optional second argument, which is an area name. Areas are useful for displaying messages in specific places within the rendered response output.
+
+When an area is not specfied, the `detault` area is used, which may not be ideal in all scenarios.
+
+For example, your layout might normally output alerts at the top of the page, but perhaps you would like to display alerts that are specific to a particular area of the layout in context, and not at the top of the page.
+
+You can achieve this by specifying an area:
+
+```php
+Alert::error('Error message', 'right-sidebar');
+```
+
+Now, this error message will be returned only when you retrieve alerts that include the `right-sidebar` area, as explained below.
+
 ### Retrieving alerts
 
 The methods below will apply the desired filters to the list of alerts, afterwards, `get` can be called in order to retrieve the alerts.


### PR DESCRIPTION
The documentation is thorough with regard to *retrieving* alerts for specific areas, but it doesn't explain how to *specify* the area when defining the alert.

Accordingly, I've added commentary and a usage example.